### PR TITLE
Fix link to explorer

### DIFF
--- a/packages/entrypoint/public/index.html
+++ b/packages/entrypoint/public/index.html
@@ -31,7 +31,8 @@
     <iframe
       src="{{APPLICATION_URL}}"
       id="frame"
-      sandbox="allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation"
+      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+      sandbox="allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation allow-forms allow-modals allow-presentation allow-downloads allow-pointer-lock"
     ></iframe>
   </body>
 

--- a/packages/entrypoint/public/index.html
+++ b/packages/entrypoint/public/index.html
@@ -31,7 +31,7 @@
     <iframe
       src="{{APPLICATION_URL}}"
       id="frame"
-      sandbox="allow-scripts allow-popups allow-same-origin"
+      sandbox="allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation"
     ></iframe>
   </body>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15332326/168286902-3569fdef-6b53-4993-89a3-ea98f2922166.png)

Currently we can't navigate to the explorer from the inside of the iframe. The first commit is enough to fix the problem, but I thought "hell, this is our own app, let's allow it anything it needs and save ourselves bugfixing in the future" and I copied all the other policies from CodeSandbox :D