### PR TITLE
Stop using hostname prefix in getApiName

### DIFF
--- a/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
+++ b/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
@@ -18,15 +18,10 @@ export const ethViewerCommands = {
   },
   getApiName: (): string | undefined => {
     const { hostname, search } = window.location;
-    let res: string | undefined = undefined;
 
     const searchParam = new URLSearchParams(search).get("explorer");
-    if (searchParam) res = searchParam;
 
-    // @todo this can be deprecated after we deploy and configure iframe entrypoints
-    if (hostname.endsWith(".deth.net")) res = hostname.slice(0, -9);
-
-    return res && res.replace(/^www\./, "");
+    return searchParam?.replace(/^www\./, "");
   },
   openRepoOnGithub: () => {
     window.open("https://github.com/dethcrypto/ethereum-code-viewer", "_blank");


### PR DESCRIPTION
Should close #67.

I've been trying to see a contract source for `rinkeby` today, and I noticed we managed to break support for explorers other than mainnet etherscan when changing domains :> This _should_ help, but I think we can test only after deploying prod.

Hostname prefix is now always `code.` and the explorer name comes from _URLSearchParams_.