### PR TITLE
Add support for multiple addresses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ cd ..
 # install deps
 pnpm install
 
-pnpm build # this builds whole vscode and can take A LOT of time
+pnpm build # this builds whole vscode and can take A LOT of time. If you are having issues, read below
 pnpm serve
 ```
 
@@ -34,6 +34,13 @@ pnpm serve
   through the `postinstall` script.
 
 - **`pnpm build`** - Builds all packages.
+
+  If you are having issues with MacOS and Python try the following:
+  ```
+  $ brew install sqlite
+  $ npm config set sqlite /opt/homebrew/opt/sqlite
+  $ npm config set python python3
+  ```
 
 - **`pnpm watch`** - Starts webpack for `ethereum-extension` in watch mode.
 

--- a/packages/ethereum-viewer/src/contributedCommands.ts
+++ b/packages/ethereum-viewer/src/contributedCommands.ts
@@ -50,11 +50,16 @@ export function registerContributedCommands(
 
       const { apiName } = picked;
 
-      const info = await openContractSource(context, { fs, address, apiName });
+      const contractName = await openContractSource(
+        context,
+        fs,
+        apiName,
+        address
+      );
 
       renderStatusBarItems({
         contractAddress: address,
-        contractName: info.ContractName || "contract",
+        contractName,
         apiName,
       });
     },

--- a/packages/ethereum-viewer/src/explorer/api-types.ts
+++ b/packages/ethereum-viewer/src/explorer/api-types.ts
@@ -31,7 +31,7 @@ export function sourceHasSettings(
   return s.startsWith("{{");
 }
 
-export function sourceHasMulitpleFiles(
+export function sourceHasMultipleFiles(
   s: SourceCode
 ): s is SourceCode.MultipleSources {
   return s.startsWith("{");

--- a/packages/ethereum-viewer/src/explorer/fetchFiles.ts
+++ b/packages/ethereum-viewer/src/explorer/fetchFiles.ts
@@ -18,12 +18,16 @@ interface FetchFilesOptions {
    * If more than 0, we fetch implementation contract and merge its files.
    */
   proxyDepth?: number;
+  /**
+   * If true multiple files are not prefixed.
+   */
+  skipPrefix?: boolean;
 }
 
 export async function fetchFiles(
   apiName: ApiName,
   contractAddress: string,
-  { fetch = _fetch, proxyDepth = 3 }: FetchFilesOptions = {}
+  { fetch = _fetch, proxyDepth = 3, skipPrefix = false }: FetchFilesOptions = {}
 ): Promise<FetchFilesResult> {
   const apiUrl = explorerApiUrls[apiName];
   const url =
@@ -72,15 +76,15 @@ export async function fetchFiles(
       files[path] = content;
     }
 
-    files = prefixFiles(files, info.ContractName);
-  } else if (types.sourceHasMulitpleFiles(sourceCode)) {
+    if (!skipPrefix) files = prefixFiles(files, info.ContractName);
+  } else if (types.sourceHasMultipleFiles(sourceCode)) {
     const parsed = types.parseSourceCode(sourceCode);
 
     for (const [path, { content }] of Object.entries(parsed)) {
       files[path] = content;
     }
 
-    files = prefixFiles(files, info.ContractName);
+    if (!skipPrefix) files = prefixFiles(files, info.ContractName);
   } else {
     files[info.ContractName + fileExtension(info)] = sourceCode;
   }

--- a/packages/ethereum-viewer/src/extension.ts
+++ b/packages/ethereum-viewer/src/extension.ts
@@ -49,15 +49,11 @@ async function main(context: vscode.ExtensionContext) {
     apiName,
   });
 
-  const info = await openContractSource(context, {
-    fs,
-    apiName,
-    address,
-  });
+  const contractName = await openContractSource(context, fs, apiName, address);
 
   renderStatusBarItems({
     contractAddress: address,
-    contractName: info.ContractName || "contract",
+    contractName,
     apiName,
   });
 }

--- a/packages/ethereum-viewer/src/openContractSource.ts
+++ b/packages/ethereum-viewer/src/openContractSource.ts
@@ -61,7 +61,11 @@ async function saveContractFilesToFs(
     const addresses = address.split(",");
     const results = await Promise.all(
       addresses.map((a) =>
-        saveSingleContractFilesToFs(fs, apiName, a, a + "/", false)
+        saveSingleContractFilesToFs(fs, apiName, a, {
+          prefix: a + "/",
+          allowProxies: false,
+          includeMainInfo: true,
+        })
       )
     );
     return {
@@ -70,57 +74,68 @@ async function saveContractFilesToFs(
       contractName: results[0].contractName,
     };
   }
-  return saveSingleContractFilesToFs(fs, apiName, address, undefined, true);
+  return saveSingleContractFilesToFs(fs, apiName, address, {
+    allowProxies: true,
+    includeMainInfo: false,
+  });
 }
 
 async function saveSingleContractFilesToFs(
   fs: FileSystem,
   apiName: explorer.ApiName,
   address: string,
-  prefix: string | undefined,
-  allowProxies: boolean
+  options: {
+    prefix?: string;
+    allowProxies: boolean;
+    includeMainInfo: boolean;
+  }
 ) {
   let result: explorer.FetchFilesResult;
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (IS_ONLINE) {
     result = await explorer.fetchFiles(apiName, address, {
-      proxyDepth: allowProxies ? undefined : 0,
+      proxyDepth: options.allowProxies ? undefined : 0,
+      skipPrefix: !!options.prefix,
     });
   } else {
     result = fixtures.etherscanResult;
   }
 
+  const withPrefix = (file: string) =>
+    options.prefix ? options.prefix + file : file;
+
   const entries = Object.entries(result.files);
   for (const [path, content] of entries) {
-    fs.writeFile(prefix ? prefix + path : path, content);
+    fs.writeFile(withPrefix(path), content);
   }
 
   const mainFile = getMainContractFile(entries, result.info);
 
+  if (options.includeMainInfo) {
+    fs.writeFile(withPrefix("main.md"), `Main file: ${mainFile}`);
+  }
+
   return {
     entries,
-    mainFile: prefix ? prefix + mainFile : mainFile,
+    mainFile: withPrefix(mainFile),
     contractName: result.info.ContractName ?? "contract",
   };
 }
 
 function getMainContractFile(
-  files: [string, ...unknown[]][],
+  files: [string, string][],
   info: explorer.FetchFilesResult["info"]
 ): string {
   const ext = fileExtension(info);
+  const name = info.implementation?.ContractName ?? info.ContractName;
 
-  let fileToShow =
-    info.implementation &&
-    files.find(([path]) =>
-      path.endsWith(`/${info.implementation!.ContractName}${ext}`)
-    );
+  let fileToShow = files.find(([path]) => path.endsWith(`/${name}${ext}`));
 
-  if (!fileToShow)
-    fileToShow = files.find(([path]) =>
-      path.endsWith(`/${info.ContractName}${ext}`)
-    );
+  if (!fileToShow) {
+    const regexp = new RegExp(`contract\\s+${name}`);
+    fileToShow = files.find(([path, source]) => regexp.test(source));
+  }
 
   if (!fileToShow) fileToShow = files.sort(byPathLength)[0];
 

--- a/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
+++ b/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
@@ -12,8 +12,6 @@ export const ethViewerCommands = {
 
     if (path.startsWith("address/")) path = path.slice(8);
     if (path.startsWith("token/")) path = path.slice(6);
-    // this is non-standard, but allows for nice short links
-    if (path.startsWith("a/")) path = path.slice(2);
     if (path.endsWith("/")) path = path.slice(0, -1);
 
     return path.startsWith("0x") ? path : undefined;

--- a/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
+++ b/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
@@ -12,6 +12,8 @@ export const ethViewerCommands = {
 
     if (path.startsWith("address/")) path = path.slice(8);
     if (path.startsWith("token/")) path = path.slice(6);
+    // this is non-standard, but allows for nice short links
+    if (path.startsWith("a/")) path = path.slice(2);
     if (path.endsWith("/")) path = path.slice(0, -1);
 
     return path.startsWith("0x") ? path : undefined;


### PR DESCRIPTION
This new mode is mainly intended for use when an external proxy detection tool is used. That way this tool can supply the main address and (possibly multiple) implementation addresses in the url and view the source code of all of them at once.

Example:
https://localhost:5001/address/0x171a2624302775eF943f4f62E76fd22A6813d7c4,0x3A4661Cc7C5D1E913Ae43f0835525802d6036eCc,0xDBE5c009095169D3de4a8D1C70E319fE647A3DBf,0x3CcB27FD59398a015a1eb465582A934fbF318214

This of course doesn't affect regular resolutions:
https://localhost:5001/address/0x99c9fc46f92e8a1c0dec1b1747d010903e884be1